### PR TITLE
Nick/feature/sim poros

### DIFF
--- a/app/facades/dnd_facade.rb
+++ b/app/facades/dnd_facade.rb
@@ -21,4 +21,9 @@ class DndFacade
       Player.new(player)
     end
   end
+
+  def monster(index)
+    monster = @service.monster(index)
+    SimMonster.new(monster)
+  end
 end

--- a/app/poros/attack.rb
+++ b/app/poros/attack.rb
@@ -1,0 +1,15 @@
+class Attack
+
+  def initialize(data)
+    @name = data[:name]
+    @description = data[:desc]
+    @action = data[:actions]
+    @hit_bonus = data[:attack_bonus]
+    @saving_throw = {
+      type: data[:dc][:name], 
+      threshold: data[:dc][:dc_value], 
+      success: data[:dc][:success_type]
+    } if data[:dc]
+    @damage_dice = data[:damage] if data[:damage]
+  end
+end

--- a/app/poros/sim_monster.rb
+++ b/app/poros/sim_monster.rb
@@ -1,5 +1,7 @@
 class SimMonster
-  attr_reader :attacks
+  attr_reader :name, :armor_class, :hit_points, :damage_dice,
+              :strength, :dexterity, :constitution, :intelligence,
+              :wisdom, :charisma, :attacks
   
   def initialize(data)
     @name = data[:name]    

--- a/app/poros/sim_monster.rb
+++ b/app/poros/sim_monster.rb
@@ -1,0 +1,26 @@
+class SimMonster
+  attr_reader :attacks
+  
+  def initialize(data)
+    @name = data[:name]    
+    @armor_class = data[:armor_class].first[:value] 
+    @hit_points = data[:hit_points]    
+    @damage_dice = data[:hit_dice]    
+    @strength = data[:strength]    
+    @dexterity = data[:dexterity]    
+    @constitution = data[:constitution]    
+    @intelligence = data[:intelligence]    
+    @wisdom = data[:wisdom]    
+    @charisma = data[:charisma]
+
+    @attacks = get_attacks(data[:actions])
+  end
+
+  private
+
+  def get_attacks(attacks_array)
+    attacks_array.map do |attack|
+      Attack.new(attack)
+    end
+  end
+end

--- a/app/services/dnd_service.rb
+++ b/app/services/dnd_service.rb
@@ -20,4 +20,8 @@ class DndService
   def players
     get_url("/api/classes")
   end
+
+  def monster(index)
+    get_url("/api/monsters/#{index}")
+  end
 end

--- a/spec/facades/dnd_facade_spec.rb
+++ b/spec/facades/dnd_facade_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe DndFacade, test: :model do
     it "#monster", :vcr do
       monster = DndFacade.new.monster("aboleth")
       expect(monster).to be_a SimMonster
+      expect(monster.name).to be_a String
+      expect(monster.armor_class).to be_a Integer
+      expect(monster.hit_points).to be_a Integer
+      expect(monster.damage_dice).to be_a String
+      expect(monster.strength).to be_a Integer
+      expect(monster.dexterity).to be_a Integer
+      expect(monster.constitution).to be_a Integer
+      expect(monster.intelligence).to be_a Integer
+      expect(monster.wisdom).to be_a Integer
+      expect(monster.charisma).to be_a Integer
+      expect(monster.attacks).to be_an Array
     end
   end
 end

--- a/spec/facades/dnd_facade_spec.rb
+++ b/spec/facades/dnd_facade_spec.rb
@@ -40,5 +40,10 @@ RSpec.describe DndFacade, test: :model do
         expect(player.url).to be_a String
       end
     end
+
+    it "#monster", :vcr do
+      monster = DndFacade.new.monster("aboleth")
+      expect(monster).to be_a SimMonster
+    end
   end
 end

--- a/spec/fixtures/vcr_cassettes/DndFacade/instance_methods/_monster.yml
+++ b/spec/fixtures/vcr_cassettes/DndFacade/instance_methods/_monster.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.dnd5eapi.co/api/monsters/aboleth
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.11
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Report-To:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1698860658&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=tcmJg5hOnY4JDkg0ppf1u4dgFHWegPan%2FsqabWp0vkQ%3D"}]}'
+      Reporting-Endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1698860658&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=tcmJg5hOnY4JDkg0ppf1u4dgFHWegPan%2FsqabWp0vkQ%3D
+      Nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '10000'
+      X-Ratelimit-Remaining:
+      - '9999'
+      Date:
+      - Wed, 01 Nov 2023 17:44:18 GMT
+      X-Ratelimit-Reset:
+      - '1698860660'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4954'
+      Etag:
+      - W/"135a-Iv/Xb2r7Ia1wMfkqpr4zBxa+GpQ"
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"index":"aboleth","name":"Aboleth","size":"Large","type":"aberration","alignment":"lawful
+        evil","armor_class":[{"type":"natural","value":17}],"hit_points":135,"hit_dice":"18d10","hit_points_roll":"18d10+36","speed":{"walk":"10
+        ft.","swim":"40 ft."},"strength":21,"dexterity":9,"constitution":15,"intelligence":18,"wisdom":15,"charisma":18,"proficiencies":[{"value":6,"proficiency":{"index":"saving-throw-con","name":"Saving
+        Throw: CON","url":"/api/proficiencies/saving-throw-con"}},{"value":8,"proficiency":{"index":"saving-throw-int","name":"Saving
+        Throw: INT","url":"/api/proficiencies/saving-throw-int"}},{"value":6,"proficiency":{"index":"saving-throw-wis","name":"Saving
+        Throw: WIS","url":"/api/proficiencies/saving-throw-wis"}},{"value":12,"proficiency":{"index":"skill-history","name":"Skill:
+        History","url":"/api/proficiencies/skill-history"}},{"value":10,"proficiency":{"index":"skill-perception","name":"Skill:
+        Perception","url":"/api/proficiencies/skill-perception"}}],"damage_vulnerabilities":[],"damage_resistances":[],"damage_immunities":[],"condition_immunities":[],"senses":{"darkvision":"120
+        ft.","passive_perception":20},"languages":"Deep Speech, telepathy 120 ft.","challenge_rating":10,"proficiency_bonus":4,"xp":5900,"special_abilities":[{"name":"Amphibious","desc":"The
+        aboleth can breathe air and water."},{"name":"Mucous Cloud","desc":"While
+        underwater, the aboleth is surrounded by transformative mucus. A creature
+        that touches the aboleth or that hits it with a melee attack while within
+        5 ft. of it must make a DC 14 Constitution saving throw. On a failure, the
+        creature is diseased for 1d4 hours. The diseased creature can breathe only
+        underwater.","dc":{"dc_type":{"index":"con","name":"CON","url":"/api/ability-scores/con"},"dc_value":14,"success_type":"none"}},{"name":"Probing
+        Telepathy","desc":"If a creature communicates telepathically with the aboleth,
+        the aboleth learns the creature''s greatest desires if the aboleth can see
+        the creature."}],"actions":[{"name":"Multiattack","multiattack_type":"actions","desc":"The
+        aboleth makes three tentacle attacks.","actions":[{"action_name":"Tentacle","count":3,"type":"melee"}]},{"name":"Tentacle","desc":"Melee
+        Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning
+        damage. If the target is a creature, it must succeed on a DC 14 Constitution
+        saving throw or become diseased. The disease has no effect for 1 minute and
+        can be removed by any magic that cures disease. After 1 minute, the diseased
+        creature''s skin becomes translucent and slimy, the creature can''t regain
+        hit points unless it is underwater, and the disease can be removed only by
+        heal or another disease-curing spell of 6th level or higher. When the creature
+        is outside a body of water, it takes 6 (1d12) acid damage every 10 minutes
+        unless moisture is applied to the skin before 10 minutes have passed.","attack_bonus":9,"dc":{"dc_type":{"index":"con","name":"CON","url":"/api/ability-scores/con"},"dc_value":14,"success_type":"none"},"damage":[{"damage_type":{"index":"bludgeoning","name":"Bludgeoning","url":"/api/damage-types/bludgeoning"},"damage_dice":"2d6+5"},{"damage_type":{"index":"acid","name":"Acid","url":"/api/damage-types/acid"},"damage_dice":"1d12"}],"actions":[]},{"name":"Tail","desc":"Melee
+        Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: 15 (3d6 + 5) bludgeoning
+        damage.","attack_bonus":9,"damage":[{"damage_type":{"index":"bludgeoning","name":"Bludgeoning","url":"/api/damage-types/bludgeoning"},"damage_dice":"3d6+5"}],"actions":[]},{"name":"Enslave","desc":"The
+        aboleth targets one creature it can see within 30 ft. of it. The target must
+        succeed on a DC 14 Wisdom saving throw or be magically charmed by the aboleth
+        until the aboleth dies or until it is on a different plane of existence from
+        the target. The charmed target is under the aboleth''s control and can''t
+        take reactions, and the aboleth and the target can communicate telepathically
+        with each other over any distance.\nWhenever the charmed target takes damage,
+        the target can repeat the saving throw. On a success, the effect ends. No
+        more than once every 24 hours, the target can also repeat the saving throw
+        when it is at least 1 mile away from the aboleth.","usage":{"type":"per day","times":3},"dc":{"dc_type":{"index":"wis","name":"WIS","url":"/api/ability-scores/wis"},"dc_value":14,"success_type":"none"},"actions":[]}],"legendary_actions":[{"name":"Detect","desc":"The
+        aboleth makes a Wisdom (Perception) check."},{"name":"Tail Swipe","desc":"The
+        aboleth makes one tail attack."},{"name":"Psychic Drain (Costs 2 Actions)","desc":"One
+        creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth
+        regains hit points equal to the damage the creature takes.","attack_bonus":0,"damage":[{"damage_type":{"index":"psychic","name":"Psychic","url":"/api/damage-types/psychic"},"damage_dice":"3d6"}]}],"image":"/api/images/monsters/aboleth.png","url":"/api/monsters/aboleth"}'
+  recorded_at: Wed, 01 Nov 2023 17:44:18 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/DndService/class_methods/_monster.yml
+++ b/spec/fixtures/vcr_cassettes/DndService/class_methods/_monster.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.dnd5eapi.co/api/monsters/aboleth
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.11
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '10000'
+      X-Ratelimit-Remaining:
+      - '9999'
+      Date:
+      - Wed, 01 Nov 2023 01:30:14 GMT
+      X-Ratelimit-Reset:
+      - '1698802215'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4954'
+      Etag:
+      - W/"135a-Iv/Xb2r7Ia1wMfkqpr4zBxa+GpQ"
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"index":"aboleth","name":"Aboleth","size":"Large","type":"aberration","alignment":"lawful
+        evil","armor_class":[{"type":"natural","value":17}],"hit_points":135,"hit_dice":"18d10","hit_points_roll":"18d10+36","speed":{"walk":"10
+        ft.","swim":"40 ft."},"strength":21,"dexterity":9,"constitution":15,"intelligence":18,"wisdom":15,"charisma":18,"proficiencies":[{"value":6,"proficiency":{"index":"saving-throw-con","name":"Saving
+        Throw: CON","url":"/api/proficiencies/saving-throw-con"}},{"value":8,"proficiency":{"index":"saving-throw-int","name":"Saving
+        Throw: INT","url":"/api/proficiencies/saving-throw-int"}},{"value":6,"proficiency":{"index":"saving-throw-wis","name":"Saving
+        Throw: WIS","url":"/api/proficiencies/saving-throw-wis"}},{"value":12,"proficiency":{"index":"skill-history","name":"Skill:
+        History","url":"/api/proficiencies/skill-history"}},{"value":10,"proficiency":{"index":"skill-perception","name":"Skill:
+        Perception","url":"/api/proficiencies/skill-perception"}}],"damage_vulnerabilities":[],"damage_resistances":[],"damage_immunities":[],"condition_immunities":[],"senses":{"darkvision":"120
+        ft.","passive_perception":20},"languages":"Deep Speech, telepathy 120 ft.","challenge_rating":10,"proficiency_bonus":4,"xp":5900,"special_abilities":[{"name":"Amphibious","desc":"The
+        aboleth can breathe air and water."},{"name":"Mucous Cloud","desc":"While
+        underwater, the aboleth is surrounded by transformative mucus. A creature
+        that touches the aboleth or that hits it with a melee attack while within
+        5 ft. of it must make a DC 14 Constitution saving throw. On a failure, the
+        creature is diseased for 1d4 hours. The diseased creature can breathe only
+        underwater.","dc":{"dc_type":{"index":"con","name":"CON","url":"/api/ability-scores/con"},"dc_value":14,"success_type":"none"}},{"name":"Probing
+        Telepathy","desc":"If a creature communicates telepathically with the aboleth,
+        the aboleth learns the creature''s greatest desires if the aboleth can see
+        the creature."}],"actions":[{"name":"Multiattack","multiattack_type":"actions","desc":"The
+        aboleth makes three tentacle attacks.","actions":[{"action_name":"Tentacle","count":3,"type":"melee"}]},{"name":"Tentacle","desc":"Melee
+        Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning
+        damage. If the target is a creature, it must succeed on a DC 14 Constitution
+        saving throw or become diseased. The disease has no effect for 1 minute and
+        can be removed by any magic that cures disease. After 1 minute, the diseased
+        creature''s skin becomes translucent and slimy, the creature can''t regain
+        hit points unless it is underwater, and the disease can be removed only by
+        heal or another disease-curing spell of 6th level or higher. When the creature
+        is outside a body of water, it takes 6 (1d12) acid damage every 10 minutes
+        unless moisture is applied to the skin before 10 minutes have passed.","attack_bonus":9,"dc":{"dc_type":{"index":"con","name":"CON","url":"/api/ability-scores/con"},"dc_value":14,"success_type":"none"},"damage":[{"damage_type":{"index":"bludgeoning","name":"Bludgeoning","url":"/api/damage-types/bludgeoning"},"damage_dice":"2d6+5"},{"damage_type":{"index":"acid","name":"Acid","url":"/api/damage-types/acid"},"damage_dice":"1d12"}],"actions":[]},{"name":"Tail","desc":"Melee
+        Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: 15 (3d6 + 5) bludgeoning
+        damage.","attack_bonus":9,"damage":[{"damage_type":{"index":"bludgeoning","name":"Bludgeoning","url":"/api/damage-types/bludgeoning"},"damage_dice":"3d6+5"}],"actions":[]},{"name":"Enslave","desc":"The
+        aboleth targets one creature it can see within 30 ft. of it. The target must
+        succeed on a DC 14 Wisdom saving throw or be magically charmed by the aboleth
+        until the aboleth dies or until it is on a different plane of existence from
+        the target. The charmed target is under the aboleth''s control and can''t
+        take reactions, and the aboleth and the target can communicate telepathically
+        with each other over any distance.\nWhenever the charmed target takes damage,
+        the target can repeat the saving throw. On a success, the effect ends. No
+        more than once every 24 hours, the target can also repeat the saving throw
+        when it is at least 1 mile away from the aboleth.","usage":{"type":"per day","times":3},"dc":{"dc_type":{"index":"wis","name":"WIS","url":"/api/ability-scores/wis"},"dc_value":14,"success_type":"none"},"actions":[]}],"legendary_actions":[{"name":"Detect","desc":"The
+        aboleth makes a Wisdom (Perception) check."},{"name":"Tail Swipe","desc":"The
+        aboleth makes one tail attack."},{"name":"Psychic Drain (Costs 2 Actions)","desc":"One
+        creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth
+        regains hit points equal to the damage the creature takes.","attack_bonus":0,"damage":[{"damage_type":{"index":"psychic","name":"Psychic","url":"/api/damage-types/psychic"},"damage_dice":"3d6"}]}],"image":"/api/images/monsters/aboleth.png","url":"/api/monsters/aboleth"}'
+  recorded_at: Wed, 01 Nov 2023 01:30:14 GMT
+recorded_with: VCR 6.2.0

--- a/spec/services/dnd_service_spec.rb
+++ b/spec/services/dnd_service_spec.rb
@@ -31,5 +31,15 @@ RSpec.describe DndService do
       expect(results[:results][0][:name]).to be_a String
       expect(results[:results][0][:url]).to be_a String
     end
+
+    it "#monster", :vcr do
+      results = DndService.new.monster("aboleth")
+      expect(results).to be_a Hash
+      expect(results[:name]).to be_a String
+      expect(results[:armor_class].first[:value]).to be_a Integer
+      expect(results[:hit_points]).to be_a Integer
+      expect(results[:proficiencies]).to be_an Array
+      expect(results[:actions]).to be_an Array
+    end
   end
 end


### PR DESCRIPTION
Neccesary checkmarks:

- [x] All Tests are Passing

- [x] The code will run locally

Type of change

- [x] New feature
- [ ] Bug Fix

Implements/Fixes:

Built the Facade and Service requests needed to build out a specific instance of a monster for use in simulations. SimMonster is a new poro with additional info we will need for running simulations in the back end, but don't need that info exposed to the user yet.

Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

Testing Changes

- [x] No Tests have been changed
- [ ] Some Tests have been changed

Checklist:

- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code