### PR TITLE
Add: grabbed monster image attribute from API to feed to front end fo…

### DIFF
--- a/app/poros/sim_monster.rb
+++ b/app/poros/sim_monster.rb
@@ -1,7 +1,7 @@
 class SimMonster
   attr_reader :name, :armor_class, :hit_points, :damage_dice,
               :strength, :dexterity, :constitution, :intelligence,
-              :wisdom, :charisma, :attacks, :id, :image
+              :wisdom, :charisma, :attacks, :id, :damage_dealt, :image
   
   def initialize(data)
     @id = nil
@@ -17,6 +17,7 @@ class SimMonster
     @charisma = data[:charisma]
 
     @attacks = get_attacks(data[:actions])
+    @damage_dealt = 0
 
     @image = data[:image]
   end

--- a/app/poros/sim_monster.rb
+++ b/app/poros/sim_monster.rb
@@ -1,7 +1,7 @@
 class SimMonster
   attr_reader :name, :armor_class, :hit_points, :damage_dice,
               :strength, :dexterity, :constitution, :intelligence,
-              :wisdom, :charisma, :attacks, :id
+              :wisdom, :charisma, :attacks, :id, :image
   
   def initialize(data)
     @id = nil
@@ -17,6 +17,8 @@ class SimMonster
     @charisma = data[:charisma]
 
     @attacks = get_attacks(data[:actions])
+
+    @image = data[:image]
   end
 
   def determine_action

--- a/app/serializers/sim_monster_serializer.rb
+++ b/app/serializers/sim_monster_serializer.rb
@@ -1,4 +1,4 @@
 class SimMonsterSerializer
   include JSONAPI::Serializer
-  attributes :id, :name, :armor_class, :hit_points, :damage_dice, :strength, :dexterity, :constitution, :intelligence, :wisdom, :charisma, :attacks
+  attributes :id, :name, :armor_class, :hit_points, :damage_dice, :strength, :dexterity, :constitution, :intelligence, :wisdom, :charisma, :attacks, :image
 end


### PR DESCRIPTION
This PR only serves to deliver the image attribute from our API calls forward to the Front end, I'm using the image url in the monster show page on the front

Neccesary checkmarks:

- [x] All Tests are Passing

- [x] The code will run locally

Type of change

- [x] New feature
- [ ] Bug Fix

Implements/Fixes:

    description closes open issue #

Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

Testing Changes

- [x] No Tests have been changed
- [ ] Some Tests have been changed

Checklist:

- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code